### PR TITLE
Updates base images to Red Hat images which are updated to patch CVEs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM node:18-alpine as builder
+FROM registry.access.redhat.com/ubi9/nodejs-18 as builder
+USER root
 WORKDIR /app
 COPY . .
 RUN npm ci
 RUN npm run build --workspace=standalone
 
-FROM nginx:1.21.0-alpine as production
+FROM registry.access.redhat.com/ubi9/nginx-120 as production
 ENV NODE_ENV production
-COPY --from=builder /app/apps/standalone/dist /usr/share/nginx/html
-EXPOSE 80
+COPY --from=builder /app/apps/standalone/dist /opt/app-root/src/
+EXPOSE 8080
+USER 1001
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
**Purpose**

The docker base images need to change in order to have images which incorporate the latest updates to patch CVEs, which these Red Hat images do.

**Changes**

- Red Hat base images for build and deploy.
- This has necessitated a change of default http port from 80 to 8080.
- Also the document root has changed.
- Some user config needed to fix permission issues.